### PR TITLE
Bump concordion dependency to 3.1.2.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ apply plugin: "jacoco"
 
 description = 'Executable API documentation in concordion'
 group = 'org.concordion'
-version = '0.0.4'
+version = '0.0.5'
 
 // bintray deployment
 // configured in gradle.properties
@@ -22,15 +22,15 @@ if (hasProperty('bintray_Username')) {
 }
 
 wrapper {
-    gradleVersion = "4.1"
+    gradleVersion = "6.5"
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 project.ext {
-    concordionVersion = "2.1.0"
+    concordionVersion = "3.1.2"
     groovyVersion = "2.4.12"
     junitVersion = "4.11"
 }

--- a/src/main/java/org/concordion/ext/apidoc/RunScriptCommand.java
+++ b/src/main/java/org/concordion/ext/apidoc/RunScriptCommand.java
@@ -14,7 +14,7 @@ final class RunScriptCommand extends AbstractCommand {
     }
 
     @Override
-    public void execute(CommandCall node, Evaluator evaluator, ResultRecorder resultRecorder) {
+    public void execute(CommandCall node, Evaluator evaluator, ResultRecorder resultRecorder, Fixture fixture) {
         String exampleName = getExampleName(node);
         SCRIPTING_LANGUAGE language = SCRIPTING_LANGUAGE.fromString(node.getExpression());
 


### PR DESCRIPTION
While working on updating bouncy-gpg to allow java modules I ran into split package issues with concordion. I'm hoping that a newer concordion version will fix the issue, so I bumped the concordion dep here in this module :)

Haven't tested with bouncy-gpg yet, that's the next step.

Here's what's changed:
Bump gradle to 6.5, use mavenCentral instead of maven.
Bump concordion dependency to 3.1.2.
Bump version to 0.0.5.
Small API fix in RunScriptCommand.java